### PR TITLE
Doc: Replace App.config with WcfWuRemoteService.exe.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 	- [Requirements](#requirements)
 	- [Installation](#installation)
 		- [Agent](#agent)
-			- [Configure App.config](#configure-appconfig)
+			- [Configure WcfWuRemoteService.exe.config](#configure-wcfwuremoteserviceexeconfig)
 			- [Configure Log.config](#configure-logconfig)
 			- [Register service](#register-service)
 			- [Least privileges](#least-privileges)
@@ -85,7 +85,7 @@ The agent is designed as long running process with a small footprint on the host
 
 Unpack the zip and copy the content to the desired location. Before you start the agent or install it as service, you may want to configure the agent. The agent is operable with the default settings. For testing purposes, you can start the agent as console application by simply executing ``WcfWuRemoteService.exe``.
 
-#### Configure App.config
+#### Configure WcfWuRemoteService.exe.config
 
 There are only a few settings, that makes sense to be changed:
 

--- a/WcfWuRemoteService/WcfWuRemoteService.csproj
+++ b/WcfWuRemoteService/WcfWuRemoteService.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Update="App.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
     <None Update="Log.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
App.config will be compiled to WcfWuRemoteService.exe.config when building.
Do not copy App.config to the build output